### PR TITLE
Remove Notfications with Object in activityDeleted()

### DIFF
--- a/src/GetStream/StreamLaravel/StreamLaravelManager.php
+++ b/src/GetStream/StreamLaravel/StreamLaravelManager.php
@@ -82,6 +82,17 @@ class StreamLaravelManager {
         $foreignId = $instance->activityForeignId();
         $feed = $this->getFeed($this->userFeed, $instance->activityActorId());
         $feed->removeActivity($foreignId, true);
+
+        if ( ! is_null($instance->activityNotify()) )
+        {
+            foreach( $instance->activityNotify() as $to )
+            {
+                $toId = explode(":", $to->getId())[1];
+
+                $notificationFeed = $this->getFeed($this->config->get("stream-laravel::notification_feed"), $toId);
+                $notificationFeed->removeActivity($foreignId, true);
+            }
+        }
     }
 
 }


### PR DESCRIPTION
So by going through `$instance->activityNotify()` and then getting the notification feed IDs you can remove the `$instance` activity from each notification feed.

This makes sense because otherwise there will be notifications pointing to nothing, and they won't be enrichable either.