### PR TITLE
fixes issue with config:cache issue #80

### DIFF
--- a/src/GetStream/StreamLaravel/StreamLaravelServiceProvider.php
+++ b/src/GetStream/StreamLaravel/StreamLaravelServiceProvider.php
@@ -37,10 +37,9 @@ class StreamLaravelServiceProvider extends ServiceProvider
         }
 
         $this->app->singleton('feed_manager', function ($app) {
-            $manager_class = $app['config']->get('stream-laravel::feed_manager_class');
-            $api_key = $app['config']->get('stream-laravel::api_key');
-            $api_secret = $app['config']->get('stream-laravel::api_secret');
-
+            $manager_class = config('stream-laravel.feed_manager_class');
+            $api_key = config('stream-laravel.api_key');
+            $api_secret = config('stream-laravel.api_secret');
             return new $manager_class($api_key, $api_secret, $this->app['config']);
         });
     }
@@ -59,12 +58,12 @@ class StreamLaravelServiceProvider extends ServiceProvider
         if (file_exists($userConfigFile)) {
             $userConfig = $this->app['files']->getRequire($userConfigFile);
             $config = array_replace_recursive($config, $userConfig);
-        }
-
-        $namespace = 'stream-laravel::';
-
-        foreach($config as $key => $value) {
-            $this->app['config']->set($namespace . $key , $value);
+        } else {
+            //only set if we dont have a config file for stream-laravel
+            $namespace = 'stream-laravel.';
+            foreach($config as $key => $value) {
+                $this->app['config']->set($namespace . $key , $value);
+            }
         }
     }
 }

--- a/src/GetStream/StreamLaravel/StreamLumenServiceProvider.php
+++ b/src/GetStream/StreamLaravel/StreamLumenServiceProvider.php
@@ -59,12 +59,12 @@ class StreamLumenServiceProvider extends ServiceProvider
         if (file_exists($userConfigFile)) {
             $userConfig = $this->app['files']->getRequire($userConfigFile);
             $config = array_replace_recursive($config, $userConfig);
-        }
-
-        $namespace = 'stream-laravel::';
-
-        foreach($config as $key => $value) {
-            $this->app['config']->set($namespace . $key , $value);
+        } else {
+            //only set if we dont have a config file for stream-laravel
+            $namespace = 'stream-laravel.';
+            foreach($config as $key => $value) {
+                $this->app['config']->set($namespace . $key , $value);
+            }
         }
     }
 }


### PR DESCRIPTION
This fixes a bug that causes artisan config:cache to not cache the values set in the .env for the config file of stream.

The original problem lies, that the register method was setting empty values. 