### PR TITLE
Fix - use dot notation to access config properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,14 +422,14 @@ For convenience we includes a basic view:
     <div class="container">
         <div class="container-pins">
             @foreach ($activities as $activity)
-                @include('stream-laravel::render_activity', ['activity' => $activity])
+                @include('stream-laravel.render_activity', ['activity' => $activity])
             @endforeach
         </div>
     </div>
 @stop
 ```
 
-The ```stream-laravel::render_activity``` view tag will render the view activity.$activity["verb"] view with the activity as context.
+The ```stream-laravel.render_activity``` view tag will render the view activity.$activity["verb"] view with the activity as context.
 
 For example activity/tweet.blade.php will be used to render an normal activity with verb tweet and aggregated_activity/like.blade.php for an aggregated activity with verb like
 
@@ -437,7 +437,7 @@ If you need to support different kind of templates for the same activity, you ca
 
 The example below will use the view activity/homepage_like.html
 ```
-@include('stream-laravel::render_activity', ['activity' => $activity, 'prefix' => 'homepage'])
+@include('stream-laravel.render_activity', ['activity' => $activity, 'prefix' => 'homepage'])
 ```
 
 

--- a/src/GetStream/StreamLaravel/StreamLaravelManager.php
+++ b/src/GetStream/StreamLaravel/StreamLaravelManager.php
@@ -38,11 +38,11 @@ class StreamLaravelManager
             $this->client = Client::herokuConnect(getenv('STREAM_URL'));
         } else {
             $this->client = new Client($api_key, $api_secret);
-            $location = $this->config->get("stream-laravel::location");
+            $location = $this->config->get("stream-laravel.location");
             $this->client->setLocation($location);
-            $this->client->timeout = $this->config->get("stream-laravel::timeout", 3);
+            $this->client->timeout = $this->config->get("stream-laravel.timeout", 3);
         }
-        $this->userFeed = $this->config->get("stream-laravel::user_feed");
+        $this->userFeed = $this->config->get("stream-laravel.user_feed");
     }
 
     /**
@@ -62,7 +62,7 @@ class StreamLaravelManager
      */
     public function getNotificationFeed($user_id)
     {
-        $user_feed = $this->config->get("stream-laravel::notification_feed");
+        $user_feed = $this->config->get("stream-laravel.notification_feed");
         return $this->client->feed($user_feed, $user_id);
     }
 
@@ -74,7 +74,7 @@ class StreamLaravelManager
     public function getNewsFeeds($user_id)
     {
         $feeds = [];
-        $news_feeds = $this->config->get("stream-laravel::news_feeds");
+        $news_feeds = $this->config->get("stream-laravel.news_feeds");
         foreach ($news_feeds as $feed) {
             $feeds[$feed] = $this->client->feed($feed, $user_id);
         }

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -9,15 +9,15 @@ class ManagerTest extends PHPUnit_Framework_TestCase
     {
         parent::setUp();
         $config = m::mock('ConfigMock');
-        $config->shouldReceive('get')->once()->with('stream-laravel::user_feed')
+        $config->shouldReceive('get')->once()->with('stream-laravel.user_feed')
             ->andReturn('user');
-        $config->shouldReceive('get')->once()->with('stream-laravel::notification_feed')
+        $config->shouldReceive('get')->once()->with('stream-laravel.notification_feed')
             ->andReturn('notification');
-        $config->shouldReceive('get')->once()->with('stream-laravel::location')
+        $config->shouldReceive('get')->once()->with('stream-laravel.location')
             ->andReturn('');
-        $config->shouldReceive('get')->once()->with('stream-laravel::news_feeds')
+        $config->shouldReceive('get')->once()->with('stream-laravel.news_feeds')
             ->andReturn(array('flat'=>'flat', 'aggregated'=>'aggregated'));
-        $config->shouldReceive('get')->once()->with('stream-laravel::timeout', 3)
+        $config->shouldReceive('get')->once()->with('stream-laravel.timeout', 3)
             ->andReturn(3);
         $this->manager = new StreamLaravelManager('key', 'secret', $config);
     }
@@ -32,15 +32,15 @@ class ManagerTest extends PHPUnit_Framework_TestCase
     {
         parent::setUp();
         $config = m::mock('ConfigMock');
-        $config->shouldReceive('get')->once()->with('stream-laravel::user_feed')
+        $config->shouldReceive('get')->once()->with('stream-laravel.user_feed')
             ->andReturn('user');
-        $config->shouldReceive('get')->once()->with('stream-laravel::notification_feed')
+        $config->shouldReceive('get')->once()->with('stream-laravel.notification_feed')
             ->andReturn('notification');
-        $config->shouldReceive('get')->once()->with('stream-laravel::location')
+        $config->shouldReceive('get')->once()->with('stream-laravel.location')
             ->andReturn('');
-        $config->shouldReceive('get')->once()->with('stream-laravel::news_feeds')
+        $config->shouldReceive('get')->once()->with('stream-laravel.news_feeds')
             ->andReturn(array('flat'=>'flat', 'aggregated'=>'aggregated'));
-        $config->shouldReceive('get')->once()->with('stream-laravel::timeout', 3)
+        $config->shouldReceive('get')->once()->with('stream-laravel.timeout', 3)
             ->andReturn(6);
         $manager = new StreamLaravelManager('key', 'secret', $config);
 


### PR DESCRIPTION
Replaced "colon" with "dot" to for `stream-laravel` config access.