### PR TITLE
Fix error forcing blank config

### DIFF
--- a/src/GetStream/StreamLaravel/StreamLumenServiceProvider.php
+++ b/src/GetStream/StreamLaravel/StreamLumenServiceProvider.php
@@ -52,7 +52,7 @@ class StreamLumenServiceProvider extends ServiceProvider
      */
     protected function registerResources()
     {
-        $userConfigFile = app()->configure('stream-laravel.php');
+        $userConfigFile = app()->getConfigurationPath('stream-laravel.php');
         $packageConfigFile = __DIR__.'/../../config/config.php';
         $config = $this->app['files']->getRequire($packageConfigFile);
 


### PR DESCRIPTION
The configure option returns void, this causes the application to overwrite the users own configuration. You would only notice when you start getting errors. The *app()->getConfigurationPath()* is more appropriate as it returns a string that can be validated against the conditional on line 59.